### PR TITLE
feat: keytrans() to handle mouse and most key presses

### DIFF
--- a/lua/keys.lua
+++ b/lua/keys.lua
@@ -17,7 +17,10 @@ local spec_table = {
     [9] = " ", [13] = "⏎ ", [27] = "⎋", [32] = "␣",
     [127] = "", [8] = "⌫ ", -- Not working
 }
--- local spc = { ["<BS>"] = "⌫ " } -- TODO: test stuff with replace_term_codes()
+local spc = {
+    ["<BS>"] = "⌫ ",
+    ["<t_\253g>"] = " ", -- lua function
+} -- TODO: test stuff with replace_term_codes()
 
 --- Get the last 5 keys
 ---@param as_string boolean (get it as string or list)
@@ -51,6 +54,23 @@ local sanitize_key = function(key)
     if b <= 126 and b >= 33 then
         return key
     end
+
+    local translated = vim.fn.keytrans(key)
+
+    local special = spc[translated]
+    if special ~= nil then
+        return special
+    end
+
+    -- Mouse events
+    if translated:match('Left')
+        or translated:match('Mouse')
+        or translated:match('Scroll')
+    then
+        return "󰍽 "
+    end
+
+    return translated
 end
 
 local register_keys = function(key)


### PR DESCRIPTION
This adds some ability to handle modifier keys - `on_key` only gets the rhs (after mapping) so this isn't as useful as I was hoping, but here's a PR in case this seems helpful. I'm assuming nerd font icons are ok. Lua fn's get mapped to the lua icon.


https://github.com/tamton-aquib/keys.nvim/assets/6422188/b403dd84-fa0d-416b-97a3-e30c2b0ecc85

